### PR TITLE
Replace panics by unreachable!

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -77,7 +77,7 @@ impl Machine {
             0xb => (3, 2),
             0xf => (3, 3),
 
-            _ => panic!("Impossible")
+            _ => unreachable!()
         }
     }
 
@@ -103,7 +103,7 @@ impl Machine {
             (3, 2) => 0xb,
             (3, 3) => 0xf,
 
-            _ => panic!("Impossible")
+            _ => unreachable!()
         }
     }
 


### PR DESCRIPTION
Was looking at the code following [your article](https://gergo.erdi.hu/blog/2017-05-12-rust_on_avr__beyond_blinking/).

Unreachable seems like a more proper way to handle out of bounds keyboard input, and in theory can enable additional optimisations by LLVM.